### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,6 @@
 name: Check Pull Request
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/puresign-tokyo/l-uploader/security/code-scanning/4](https://github.com/puresign-tokyo/l-uploader/security/code-scanning/4)

To fix the problem, explicitly set minimal `GITHUB_TOKEN` permissions in this workflow. Since this job only checks differences in a file using `git fetch` and `git diff` and does not need to write to the repository, we can safely restrict permissions to `contents: read`. This satisfies the principle of least privilege and the CodeQL recommendation.

The best change with no functional impact is to add a `permissions:` block at the workflow root so it applies to all jobs. In `.github/workflows/push.yml`, add:

```yaml
permissions:
  contents: read
```

immediately after the `name: Check Pull Request` line and before the `on:` block (lines 1–2). No additional imports, methods, or definitions are required, and no existing steps need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
