### PR TITLE
フロントエンドで予期せぬタイミングで関数を読んでしまいエラーが出てしまうことの修正

### DIFF
--- a/frontend/app/components/Dialogs/DeleteDialog.vue
+++ b/frontend/app/components/Dialogs/DeleteDialog.vue
@@ -78,12 +78,13 @@
 import { ref } from "vue";
 import { useI18n } from "#imports";
 import { useRuntimeConfig } from "#imports";
-import { BackendUrl } from "~/composables/Settings";
+import { useBackendUrl } from "~/composables/Settings";
 const { t: i18nT } = useI18n();
 const deletePassword = ref("");
 const showPassword = ref(false);
 const deleteDialog = defineModel<boolean>();
 const config = useRuntimeConfig().public;
+const backendUrl = useBackendUrl();
 
 const recaptchaRef = ref<HTMLElement | null>(null);
 let widgetId: number | null = null;
@@ -202,7 +203,7 @@ async function sendDeleteReplay() {
   }
 
   try {
-    await $fetch(`${BackendUrl()}/replays/${props.replay_id}`, {
+    await $fetch(`${backendUrl}/replays/${props.replay_id}`, {
       method: "delete",
       body: {
         delete_password: deletePassword.value,

--- a/frontend/app/components/ReplayTable.vue
+++ b/frontend/app/components/ReplayTable.vue
@@ -333,7 +333,7 @@
 
                   <a
                     v-if="props.replayTable.replay_id"
-                    :href="`${BackendUrl()}/replays/${
+                    :href="`${backendUrl}/replays/${
                       props.replayTable.replay_id
                     }/file`"
                     target="_blank"
@@ -392,10 +392,11 @@
 <script setup lang="ts">
 import { useDisplay } from "vuetify";
 import { useI18n, useLocalePath } from "#imports";
-import { BackendUrl } from "~/composables/Settings";
+import { useBackendUrl } from "~/composables/Settings";
 const { t: i18nT } = useI18n();
 const localePath = useLocalePath();
 const display = useDisplay();
+const backendUrl = useBackendUrl();
 
 interface ReplayTable {
   game_meta: {

--- a/frontend/app/composables/Settings.ts
+++ b/frontend/app/composables/Settings.ts
@@ -1,4 +1,4 @@
-export function BackendUrl() {
+export function useBackendUrl() {
   const config = useRuntimeConfig().public;
   const httpProtocol = String(config.httpProtocol);
   const backendHost = String(config.backendHost);

--- a/frontend/app/pages/NewPost.vue
+++ b/frontend/app/pages/NewPost.vue
@@ -274,7 +274,7 @@
 import { ClientOnly } from "#components";
 import { ref } from "vue";
 import { useI18n } from "#imports";
-import { BackendUrl } from "~/composables/Settings";
+import { useBackendUrl } from "~/composables/Settings";
 import { useRuntimeConfig } from "#imports";
 
 const router = useRouter();
@@ -289,6 +289,7 @@ const optionalTag = ref("");
 const dialogSuccessPost = ref(false);
 const pendingTweetText = ref("");
 const showPassword = ref(false);
+const backendUrl = useBackendUrl();
 const config = useRuntimeConfig().public;
 
 const { t: i18nT } = useI18n();
@@ -474,7 +475,7 @@ async function sendPostReplay() {
   formData.append("optional_tag", optionalTag.value);
   formData.append("recaptcha_token", response);
   try {
-    await $fetch(`${BackendUrl()}/replays`, {
+    await $fetch(`${backendUrl}/replays`, {
       method: "post",
       body: formData,
       onResponse({ response }) {

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -197,7 +197,7 @@ import { ref, watch } from "vue";
 import { useDisplay } from "vuetify";
 import { ClientOnly } from "#components";
 import { useI18n } from "#imports";
-import { BackendUrl } from "~/composables/Settings";
+import { useBackendUrl } from "~/composables/Settings";
 import { useRuntimeConfig } from "#imports";
 
 import ReplayTable from "~/components/ReplayTable.vue";
@@ -236,6 +236,7 @@ const loadingReplayCounts = ref(true);
 const deleteDialog = ref(false);
 const shareDialog = ref(false);
 const config = useRuntimeConfig().public;
+const backendUrl = useBackendUrl();
 const { t: i18nT, locale } = useI18n();
 
 const snackbar = ref({
@@ -363,7 +364,7 @@ async function fetchReplayCounts() {
   const params = new URLSearchParams(buildCommonParams());
   try {
     const countData = await $fetch(
-      `${BackendUrl()}/replays/count?${params.toString()}`,
+      `${backendUrl}/replays/count?${params.toString()}`,
       {
         method: "get",
         server: false,
@@ -392,7 +393,7 @@ async function fetchReplays(page) {
   });
   try {
     const replaysData = await $fetch(
-      `${BackendUrl()}/replays?${params.toString()}`,
+      `${backendUrl}/replays?${params.toString()}`,
       {
         method: "get",
         server: false,

--- a/frontend/app/pages/replays/[replay_id].vue
+++ b/frontend/app/pages/replays/[replay_id].vue
@@ -44,9 +44,7 @@
               <v-fab icon="mdi-share-variant" @click="shareDialog = true" />
               <a
                 v-if="replayTable.replay_id"
-                :href="`${BackendUrl()}/replays/${
-                  replayTable.replay_id
-                }/file`"
+                :href="`${backendUrl}/replays/${replayTable.replay_id}/file`"
                 target="_blank"
                 rel="noopener"
                 style="text-decoration: none; color: inherit"
@@ -101,7 +99,7 @@
                           class="mr-1"
                           :title="
                             i18nT(
-                              'pages.replays.replay_id.template.card.user_name'
+                              'pages.replays.replay_id.template.card.user_name',
                             )
                           "
                         >
@@ -270,7 +268,7 @@
                     class="mr-1"
                     :title="
                       i18nT(
-                        'pages.replays.replay_id.template.card.optional_tag'
+                        'pages.replays.replay_id.template.card.optional_tag',
                       )
                     "
                   >
@@ -279,7 +277,7 @@
                   <span>
                     {{
                       i18nT(
-                        "pages.replays.replay_id.template.card.optional_tag"
+                        "pages.replays.replay_id.template.card.optional_tag",
                       )
                     }}
                   </span>
@@ -358,7 +356,7 @@
                     class="mr-1"
                     :title="
                       i18nT(
-                        'pages.replays.replay_id.template.card.upload_comment'
+                        'pages.replays.replay_id.template.card.upload_comment',
                       )
                     "
                   >
@@ -367,7 +365,7 @@
                   <span>
                     {{
                       i18nT(
-                        "pages.replays.replay_id.template.card.upload_comment"
+                        "pages.replays.replay_id.template.card.upload_comment",
                       )
                     }}
                   </span>
@@ -396,7 +394,7 @@
                     class="mr-1"
                     :title="
                       i18nT(
-                        'pages.replays.replay_id.template.card.stage_splits'
+                        'pages.replays.replay_id.template.card.stage_splits',
                       )
                     "
                   >
@@ -405,7 +403,7 @@
                   <span>
                     {{
                       i18nT(
-                        "pages.replays.replay_id.template.card.stage_splits"
+                        "pages.replays.replay_id.template.card.stage_splits",
                       )
                     }}
                   </span>
@@ -424,7 +422,7 @@
                   <span v-else>
                     {{
                       i18nT(
-                        "pages.replays.replay_id.template.card.cant_show_stage_splits"
+                        "pages.replays.replay_id.template.card.cant_show_stage_splits",
                       )
                     }}
                   </span>
@@ -460,7 +458,7 @@
         :upload_comment="
           replayTable.upload_comment ??
           i18nT(
-            'pages.replays.replay_id.template.dialog.unknown.upload_comment'
+            'pages.replays.replay_id.template.dialog.unknown.upload_comment',
           )
         "
         :game_name="replayTable.game_meta.name"
@@ -493,7 +491,7 @@
 import { useDisplay } from "vuetify";
 import { I18nT, useI18n } from "vue-i18n";
 import { ClientOnly } from "#components";
-import { BackendUrl } from "~/composables/Settings";
+import { useBackendUrl } from "~/composables/Settings";
 import DeleteDialog from "~/components/Dialogs/DeleteDialog.vue";
 import ShareDialog from "~/components/Dialogs/ShareDialog.vue";
 
@@ -522,6 +520,7 @@ import { AlcoTable } from "~/composables/Games/Alco";
 
 const display = useDisplay();
 const { t: i18nT, locale } = useI18n();
+const backendUrl = useBackendUrl();
 
 type StageDetailsRow = Record<string, string | number | boolean | null>;
 
@@ -600,12 +599,10 @@ const tableComponents: Record<string, TableParser> = {
 async function refreshReplay() {
   try {
     const response = await $fetch<{ game_id: string }>(
-      `${BackendUrl()}/replays/${
-        route.params.replay_id
-      }`,
+      `${backendUrl}/replays/${route.params.replay_id}`,
       {
         method: "get",
-      }
+      },
     );
     if (tableComponents[response?.game_id]) {
       replayTable = tableComponents[response?.game_id](response);


### PR DESCRIPTION
BackendUrlの関数をsetup中に呼ぶようにした

現状であるとsetup中に関数を呼ばないので下記のようなエラーが出てしまう
```
    at async setup (file:///app/.output/server/chunks/build/index-5RYIv4Cz.mjs:2716:91)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at refreshReplays (file:///app/.output/server/chunks/build/index-5RYIv4Cz.mjs:2714:13)
    at fetchReplays (file:///app/.output/server/chunks/build/index-5RYIv4Cz.mjs:2689:14)
    at BackendUrl (file:///app/.output/server/chunks/build/Settings-CvwSTJya.mjs:4:18)
    at useRuntimeConfig (file:///app/.output/server/chunks/build/server.mjs:243:10)
    at useNuxtApp (file:///app/.output/server/chunks/build/server.mjs:236:13)
Error: [nuxt] instance unavailable
```